### PR TITLE
Fix optional Time fields

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -35,7 +35,7 @@ func TestGetForecast(t *testing.T) {
 	}
 
 	if curr.NearestStormDistance != 3 {
-		t.Errorf("Got incorrect NearestStormDistance %d", curr.NearestStormDistance)
+		t.Errorf("Got incorrect NearestStormDistance %f", curr.NearestStormDistance)
 	}
 
 	if curr.Temperature != 55.13 {

--- a/data-point.go
+++ b/data-point.go
@@ -8,9 +8,9 @@ package darksky
 type DataPoint struct {
 	ApparentTemperature        float64 `json:"apparentTemperature,omitempty"`
 	ApparentTemperatureMax     float64 `json:"apparentTemperatureMax,omitempty"`
-	ApparentTemperatureMaxTime Time    `json:"apparentTemperatureMaxTime,omitempty"`
+	ApparentTemperatureMaxTime *Time   `json:"apparentTemperatureMaxTime,omitempty"`
 	ApparentTemperatureMin     float64 `json:"apparentTemperatureMin,omitempty"`
-	ApparentTemperatureMinTime Time    `json:"apparentTemperatureMinTime,omitempty"`
+	ApparentTemperatureMinTime *Time   `json:"apparentTemperatureMinTime,omitempty"`
 	CloudCover                 float64 `json:"cloudCover,omitempty"`
 	DewPoint                   float64 `json:"dewPoint,omitempty"`
 	Humidity                   float64 `json:"humidity,omitempty"`
@@ -22,7 +22,7 @@ type DataPoint struct {
 	PrecipAccumulation         float64 `json:"precipAccumulation"`
 	PrecipIntensity            float64 `json:"precipIntensity"`
 	PrecipIntensityMax         float64 `json:"precipIntensityMax"`
-	PrecipIntensityMaxTime     Time    `json:"precipIntensityMaxTime"`
+	PrecipIntensityMaxTime     *Time   `json:"precipIntensityMaxTime,omitempty"`
 	PrecipProbability          float64 `json:"precipProbability"`
 	PrecipType                 string  `json:"precipType"`
 	Pressure                   float64 `json:"pressure"`


### PR DESCRIPTION
The optional time fields are set to incorrect values (zero-time) now:

```
{
  "latitude": 55.7507,
  "longitude": 37.6177,
  "timezone": "Europe/Moscow",
  "currently": {
    "apparentTemperature": 25.84,
    "apparentTemperatureMaxTime": -62135596800,
    "apparentTemperatureMinTime": -62135596800,
    "cloudCover": 1,
    "dewPoint": 30.59,
    "humidity": 0.93,
    "icon": "fog",
    "ozone": 292.87,
    "precipAccumulation": 0,
    "precipIntensity": 0.0005,
    "precipIntensityMax": 0,
    "precipIntensityMaxTime": -62135596800,
    "precipProbability": 0.04,
    "precipType": "snow",
    "pressure": 1018.44,
    "summary": "Foggy",
    "sunriseTime": 0,
    "sunsetTime": 0,
    "temperature": 32.31,
    "temperatureMax": 0,
    "temperatureMaxTime": 0,
    "temperatureMin": 0,
    "temperatureMinTime": 0,
    "time": 1513685120,
    "visibility": 0.57,
    "windBearing": 56,
    "windSpeed": 7.05
  },
```

This PR fixes this.