### PR TITLE
Actualize flags

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -6,7 +6,7 @@
 package darksky
 
 type Flags struct {
-	DarkSkyUnavailable bool     `json:"darksky-unavailable"`
-	MetNoLicense       bool     `json:"meto-license"`
+	DarkSkyUnavailable string   `json:"darksky-unavailable"`
 	Sources            []string `json:"sources"`
+	Units              string   `json:"units"`
 }


### PR DESCRIPTION
Fix flags according to [documentation](https://darksky.net/dev/docs#flags).
1. I haven't found anything about **MetNoLicense**.
2. **DarkSkyUnavailable** is actually not a bool, but a string. 
    ```
    "flags": {
      "darksky-unavailable": "Dark Sky covers the given location, but all stations are currently unavailable.",
      "sources": [
        "isd",
        "cmc",
        "gfs",
        "hrrr",
        "madis",
        "nam",
        "sref",
        "darksky"
      ],
      "units": "us"
     },
    ```
And the whole request fails because of conversion failure: `json: cannot unmarshal string into Go struct field Flags.darksky-unavailable of type bool`.